### PR TITLE
replace use of `string_t` with `string_table`

### DIFF
--- a/src/zvdb_000/zcl_vdb_000_dotenv.clas.abap
+++ b/src/zvdb_000/zcl_vdb_000_dotenv.clas.abap
@@ -120,8 +120,8 @@ CLASS ZCL_VDB_000_DOTENV IMPLEMENTATION.
 
 
   METHOD parse_file.
-    DATA: lt_file_content TYPE string_t,
-          lt_split        TYPE string_t.
+    DATA: lt_file_content TYPE string_table,
+          lt_split        TYPE string_table.
 
     CALL METHOD cl_gui_frontend_services=>gui_upload
       EXPORTING

--- a/src/zvdb_002/zcl_vdb_002_lib.clas.abap
+++ b/src/zvdb_002/zcl_vdb_002_lib.clas.abap
@@ -1606,7 +1606,7 @@ CLASS ZCL_VDB_002_LIB IMPLEMENTATION.
 
   METHOD quantize_from_string.
     TYPES: tt_f TYPE TABLE OF f WITH DEFAULT KEY.
-    DATA:lt_s TYPE string_t.
+    DATA:lt_s TYPE string_table.
     DATA:lt_f TYPE tt_f.
     DATA:lt_v TYPE tt_embedding.
     SPLIT iv_ AT space INTO TABLE lt_s.

--- a/src/zvdb_002/zvdb_002_demo_01_upload.prog.abap
+++ b/src/zvdb_002/zvdb_002_demo_01_upload.prog.abap
@@ -140,7 +140,7 @@ CLASS lcl_ IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD go.
-    DATA:lt_s TYPE string_t.
+    DATA:lt_s TYPE string_table.
     DATA:lt_v TYPE zcl_vdb_002_lib=>tt_embedding.
     DATA(lt_) = me->import( ).
 

--- a/src/zvdb_002/zvdb_002_demo_02_query.prog.abap
+++ b/src/zvdb_002/zvdb_002_demo_02_query.prog.abap
@@ -510,7 +510,7 @@ CLASS lcl_ IMPLEMENTATION.
 
   ENDMETHOD.
   METHOD embed.
-    DATA: lt_text TYPE string_t.
+    DATA: lt_text TYPE string_table.
 
     CALL FUNCTION 'TERM_CONTROL_EDIT'
       EXPORTING
@@ -537,7 +537,7 @@ CLASS lcl_ IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD answer.
-    DATA: lt_text TYPE string_t.
+    DATA: lt_text TYPE string_table.
 
     CALL FUNCTION 'TERM_CONTROL_EDIT'
       EXPORTING

--- a/src/zvdb_002/zvdb_002_demo_03_reindex.prog.abap
+++ b/src/zvdb_002/zvdb_002_demo_03_reindex.prog.abap
@@ -41,7 +41,7 @@ AT SELECTION-SCREEN.
   ENDCASE.
 
 FORM embed.
-  DATA: lt_text TYPE string_t.
+  DATA: lt_text TYPE string_table.
 
   CALL FUNCTION 'TERM_CONTROL_EDIT'
     EXPORTING


### PR DESCRIPTION
https://abaplint.app/stats/oisee/zvdb/void_types

`string_t` does not exist in dev edition 1909

`string_table` is released plus exists on 702 and up, https://abapedia.org/steampunk-2305-api/string_table.ttyp.html

![image](https://github.com/oisee/zvdb/assets/5888506/1c3d492a-a397-4ecc-8161-b36cf34124f2)
